### PR TITLE
feat: Pack/Closet -> Fixed indexing issues for swapping between packs…

### DIFF
--- a/server/routes/closet/closetController.ts
+++ b/server/routes/closet/closetController.ts
@@ -83,21 +83,27 @@ async function moveGearClosetItem(req: Request, res: Response) {
 	}
 }
 
+//to test?
 async function moveItemToPack(req: Request, res: Response) {
 	try {
 		const { userId } = req;
 		const { packItemId } = req.params;
-		const { pack_id, pack_category_id } = req.body;
+		const { pack_id, pack_category_id, pack_item_index } = req.body;
 
-		const pack_item_index = await generateIndex('pack_items', 'pack_item_index', {
+		const newPackItemIndex = await generateIndex('pack_items', 'pack_item_index', {
 			user_id: userId,
 			pack_id,
 			pack_category_id,
 		});
 
 		await knex('pack_items')
-			.update({ pack_id, pack_category_id, pack_item_index })
+			.update({ pack_id, pack_category_id, pack_item_index: newPackItemIndex })
 			.where({ user_id: userId, pack_item_id: packItemId });
+
+		await knex.raw(`UPDATE pack_items 
+				SET pack_item_index = pack_item_index - 1 
+				WHERE pack_item_index >= ${pack_item_index}
+				AND pack_category_id IS NULL`);
 
 		return res.status(200).send();
 	} catch (err) {

--- a/server/routes/pack/packRoutes.ts
+++ b/server/routes/pack/packRoutes.ts
@@ -19,7 +19,7 @@ router.delete('/pack-items/:packItemId', packController.deletePackItem);
 router.post('/categories/:packId', packController.addPackCategory);
 router.put('/categories/:categoryId', packController.editPackCategory);
 router.put('/categories/index/:categoryId', packController.movePackCategory);
-router.delete('/categories/:categoryId', packController.deletePackCategory);
+router.delete('/categories/:categoryId', packController.moveCategoryToCloset);
 router.delete('/categories/items/:categoryId', packController.deleteCategoryAndItems);
 
 export default router;

--- a/server/routes/pack/packUtils.ts
+++ b/server/routes/pack/packUtils.ts
@@ -40,15 +40,30 @@ async function generateIndex(
 		pack_item_id?: number;
 	},
 ): Promise<number> {
-	const response = await knex(tableName)
-		.select(knex.raw(`MAX(${indexName})`))
-		.where(conditions)
-		.first();
-	if ('max' in response) {
-		if (typeof response['max'] === 'number') return response['max'] + 1;
-		else return 0;
-	}
-	return 0;
+	const maxResult = await knex(tableName).max(indexName).where(conditions).first();
+	return maxResult?.max + 1 || 0;
+	// const response = await knex(tableName)
+	// 	.select(knex.raw(`MAX(${indexName})`))
+	// 	.where(conditions)
+	// 	.first();
+	// if ('max' in response) {
+	// 	if (typeof response['max'] === 'number') return response['max'] + 1;
+	// 	else return 0;
+	// }
+	// return 0;
 }
 
-export { generateIndex, changeItemOrder };
+async function getMaxItemIndex(user_id: number, pack_id: string | number | null) {
+	try {
+		const maxResult = await knex('pack_items')
+			.max('pack_item_index')
+			.where({ user_id, pack_id })
+			.first();
+
+		return maxResult?.max || 0;
+	} catch (err) {
+		return new Error('');
+	}
+}
+
+export { generateIndex, changeItemOrder, getMaxItemIndex };


### PR DESCRIPTION
- Categories returns empty array instead of [ NULL ] for categories without items
- Max index finding utility functions refactored to be more succinct 
- Moving item to pack adjusts indexes of items left in gear closet
- Moving single item to gear closet now updates indexes of pack categories it left
- 