### PR TITLE
Add domain cookie

### DIFF
--- a/server/routes/authentication/authentication.test.ts
+++ b/server/routes/authentication/authentication.test.ts
@@ -55,7 +55,7 @@ describe('Auth Routes: ', () => {
 
 	it.skip('POST /register -> Should NOT allow existing username to be registered', async () => {
 		notSeededUser.username = mockUser.username;
-		console.log('not seeded user: ', notSeededUser);
+
 		const response = await request.post('/auth/register').send(notSeededUser);
 
 		expect(response.statusCode).toEqual(409);

--- a/server/routes/authentication/authenticationController.ts
+++ b/server/routes/authentication/authenticationController.ts
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 import knex from '../../db/connection.js';
 import { Request, Response } from 'express';
 import { tables as t } from '../../../knexfile.js';
-import { cookieName, cookieOptions } from '../../utils/utils.js';
+import { cookieName, cookieOptions, domainName } from '../../utils/utils.js';
 import { supabase } from '../../db/supabaseClient.js';
 import { generateUsername } from '../../utils/usernameGenerator.js';
 
@@ -85,7 +85,7 @@ async function login(req: Request, res: Response) {
 }
 
 async function logout(_req: Request, res: Response) {
-	return res.status(200).clearCookie(cookieName).json({
+	return res.status(200).clearCookie(cookieName, { domain: domainName }).json({
 		message: 'User has been logged out.',
 	});
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -14,10 +14,13 @@ export const knexCamelCaseResponse = (result: KnexResponse) => {
 export const cookieName =
 	process.env.NODE_ENV === 'production' ? 'tidyToken' : 'tidyToken';
 
+export const domainName =
+	process.env.NODE_ENV === 'production' ? 'tidytrek.co' : 'localhost';
 // todo: '__Host-tidyToken'
 
 export const cookieOptions = {
 	httpOnly: true,
 	maxAge: 1000 * 60 * 60 * 24 * 180, // 180 days
 	signed: true,
+	domain: domainName,
 };

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -11,11 +11,10 @@ export const knexCamelCaseResponse = (result: KnexResponse) => {
 	return result;
 };
 
-export const cookieName =
-	process.env.NODE_ENV === 'production' ? 'tidyToken' : 'tidyToken';
+export const cookieName = 'tidy_token';
 
 export const domainName =
-	process.env.NODE_ENV === 'production' ? 'tidytrek.co' : 'localhost';
+	process.env.NODE_ENV === 'production' ? 'tidytrek.co' : undefined;
 // todo: '__Host-tidyToken'
 
 export const cookieOptions = {


### PR DESCRIPTION
-Add domain to cookie option to allow frontend to attach token to requests for frontend.
-This allows us to serve content based on tidy_token.