### PR TITLE
fix(deploy): copy ecosystem.config.cjs to dist during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"commit": "cz",
-		"build": "npx tsc",
+		"build": "npx tsc && cp ecosystem.config.cjs dist/",
 		"start": "NODE_ENV=production node --import=./instrument.js server/index.js",
 		"pm2:start": "/usr/local/bin/pm2 start ecosystem.config.cjs",
 		"pm2:restart": "/usr/local/bin/pm2 restart tidytrek-api || npm run pm2:start",


### PR DESCRIPTION
# Pull Request

## Summary
Copy ecosystem.config.cjs to dist during build
- TS compilation doesn't pick up cjs files.

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally
- [x] No breaking changes